### PR TITLE
Add the SICP lectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ There are a lot of screencasts, recordings of user group gatherings and conferen
 * [Microservices](https://www.youtube.com/watch?v=wgdBVIX9ifA) by **Martin Fowler** [26.25]
 * [Stewardship: The Sobering Parts](https://www.youtube.com/watch?v=2y5Pv4yN0b0) by **Brian Goetz** [1:03:30]
 * [Theraputic Refactoring](https://www.youtube.com/watch?v=J4dlF0kcThQ) by **Katrina Owen** [26:04]
+* [Structure and Interpretation of Computer Programs](http://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-001-structure-and-interpretation-of-computer-programs-spring-2005/video-lectures/) by **Hal Abelson and Gerald Jay Sussman** (Several lectures)
 
 #####Web Development
 


### PR DESCRIPTION
They are still a fundamental part of great video lectures about software design. I don't know if this is the right section for them, but the lessons are about different styles of programming, all done with the Scheme language.
